### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ import easy_scpi as scpi
 class PowerSupply( scpi.Instrument ):
     
     def __init__( self ):
-        scpi.SCPI_Instrument.__init__( 
+        scpi.Instrument.__init__( 
             self, 
             port = None, 
             timeout = 5,


### PR DESCRIPTION
Correct Class Example in README. Without this change, you will get a `module 'easy_scpi' has no attribute 'SCPI_Instrument'` error because init.py has this line: `from easy_scpi.scpi_instrument import SCPI_Instrument as Instrument`