### PR TITLE
Add ability to explicitly query by passing '?' as first argument.

### DIFF
--- a/easy_scpi/scpi_instrument.py
+++ b/easy_scpi/scpi_instrument.py
@@ -101,14 +101,17 @@ class Property( object ):
             if len( values ) == 0:
                 # get property
                 return self.__inst.query( f'{ self.name }?')
+            # will len(values) >= here
+            # set value
+            values = [ str( val ) for val in values ]
+            # allow for queries with additional arguments
+            if query := values[0] in ('?',):
+                values.pop(0)
+            values = self.arg_separator.join( values )
 
-            else:
-                # set value
-                values = [ str( val ) for val in values ]
-                values = self.arg_separator.join( values )
-
-                cmd = f'{ self.name } { values }'
-                return self.__inst.write( cmd )
+            cmd = f'{ self.name }{ "?" if query else "" } { values }'
+            fn = self.__inst.query if query else self.__inst.write
+            return fn( cmd )
 
 
         #--- static methods ---


### PR DESCRIPTION
Tested with dummy instrument that simply prints the compiled SCPI string and whether it is querying or writing.

Some of the instruments that I am working with have the option to or require arguments after the question mark when querying a value. For example, modules used with a Keysight DAQ970 can have specific channels queried. For example,  `MEAS:VOLT:DC? 10,0.001,(@101, 102, 103)` measure the DC voltage w/ 10V range, 1mV resolution, on channels 01, 02, and 03 of module 1.

As mentioned in the commit message, I've only tested this with a "fake" VISA instrument so far: 
```python
class FakeInst:
    def write(self, cmd):
        print(f"writing `{cmd}`")
    def query(self, msg):
        return input(f"asking `{msg}` > ")
```

If you'd prefer tests with an actual VISA instrument, let me know. Also, if you have particular formatting preferences let me know what they are.