### PR TITLE
Add optional cmd_prefix for devices that require a prefix at the star…

### DIFF
--- a/easy_scpi/scpi_instrument.py
+++ b/easy_scpi/scpi_instrument.py
@@ -175,6 +175,7 @@ class SCPI_Instrument():
         backend = '',
         handshake = False,
         arg_separator = ',',
+        cmd_prefix = '',
         **resource_params
     ):
         """
@@ -184,6 +185,7 @@ class SCPI_Instrument():
         :param backend: The pyvisa backend to use for communication. [Defualt: '']
         :param handshake: Handshake mode. [Default: False]
         :param arg_separator: Separator to use between arguments. [Default: ',']
+        :param cmd_prefix: Optional prefix for commands. [Default: '']
         :param resource_params: Arguments sent to the resource upon connection.
             https://pyvisa.readthedocs.io/en/latest/api/resources.html
         :returns: An Instrument communicator.
@@ -197,10 +199,12 @@ class SCPI_Instrument():
         self.__rid = None  # the resource id of the instrument
         self.__resource_params = resource_params  # options for connection
 
-
         # init connection
         self.port = port  # initilaize port
+
+        # init command parameters
         self.arg_separator = arg_separator
+        self.cmd_prefix = cmd_prefix
 
         if handshake is True:
             handshake = 'OK'
@@ -220,7 +224,7 @@ class SCPI_Instrument():
 
 
     def __getattr__( self, name ):
-        resp = Property( self, name, arg_separator = self.arg_separator )
+        resp = Property( self, self.cmd_prefix+name, arg_separator = self.arg_separator )
         return resp
 
 

--- a/easy_scpi/scpi_instrument.py
+++ b/easy_scpi/scpi_instrument.py
@@ -175,7 +175,7 @@ class SCPI_Instrument():
         backend = '',
         handshake = False,
         arg_separator = ',',
-        cmd_prefix = '',
+        prefix_cmds = False,
         **resource_params
     ):
         """
@@ -185,7 +185,7 @@ class SCPI_Instrument():
         :param backend: The pyvisa backend to use for communication. [Defualt: '']
         :param handshake: Handshake mode. [Default: False]
         :param arg_separator: Separator to use between arguments. [Default: ',']
-        :param cmd_prefix: Optional prefix for commands. [Default: '']
+        :param prefix_cmds: Option to prefix all commands with a colon. [Default: False]
         :param resource_params: Arguments sent to the resource upon connection.
             https://pyvisa.readthedocs.io/en/latest/api/resources.html
         :returns: An Instrument communicator.
@@ -204,7 +204,7 @@ class SCPI_Instrument():
 
         # init command parameters
         self.arg_separator = arg_separator
-        self.cmd_prefix = cmd_prefix
+        self.prefix_cmds = prefix_cmds
 
         if handshake is True:
             handshake = 'OK'
@@ -224,7 +224,7 @@ class SCPI_Instrument():
 
 
     def __getattr__( self, name ):
-        resp = Property( self, self.cmd_prefix+name, arg_separator = self.arg_separator )
+        resp = Property( self, self.prefix_cmds*":"+name, arg_separator = self.arg_separator )
         return resp
 
 


### PR DESCRIPTION
Add optional cmd_prefix for devices that require a prefix at the start of a command of a scpi command. 

For example with a prefix of ':' the command output will be :MEASure:VOLTage rather than MEASure:VOLTage. 

```py
>> inst.MEAS.VOLT.name
'MEAS:VOLT'

>>> inst.cmd_prefix = ':'
>>> inst.MEAS.VOLT.name
':MEAS:VOLT'
```
Relatively simple addition to solve #16 