### PR TITLE
Query with arguments built in.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple and robust library making communication with [SCPI](https://en.wikipedi
 
 ## API
 ### SCPI Commands
-Generic SCPI commands can be executed by transforming the SCPI code in to attributes via the hierarchy relationship, then calling it. Instrument properties can be queried by passing no arguments to the call. Commands with no arguments are run by passing an empty string to the call.
+Generic SCPI commands can be executed by transforming the SCPI code in to attributes via the hierarchy relationship, then calling it. Instrument properties can be queried by passing no arguments to the call (or specifying query=True). Commands with no arguments are run by passing an empty string to the call.
 
 #### Examples
 ~~~python
@@ -19,6 +19,9 @@ inst = scpi.Instrument( <port> )
 inst.measure.voltage.dc()
 # or
 inst.meas.volt.dc()
+
+# Passing args to a query [MEASure:VOLTage:DC? MIN]
+inst.measure.voltage.dc("MIN", query=True)
 
 # Set the voltage to 1 V [MEASure:VOLTage:DC 1]
 inst.measure.voltage.dc( 1 )

--- a/easy_scpi/scpi_instrument.py
+++ b/easy_scpi/scpi_instrument.py
@@ -97,18 +97,23 @@ class Property( object ):
             )
 
 
-        def __call__( self, *values ):
-            if len( values ) == 0:
-                # get property
-                return self.__inst.query( f'{ self.name }?')
-
-            else:
-                # set value
+        def __call__( self, *values, query=False):
+            """
+            Calls an SCPI command. If no values are passed it acts as a query 'COMMand?'
+            If values are passed it acts as a write 'COMMand [values]'.
+            For queries that require arguments, query=True can be passed.
+            """
+            # Set up command format.
+            command = '{cmd}'
+            if args_passed := len( values ) > 0:
+                # Parse args into understandable format
                 values = [ str( val ) for val in values ]
-                values = self.arg_separator.join( values )
-
-                cmd = f'{ self.name } { values }'
-                return self.__inst.write( cmd )
+                command += ' '+self.arg_separator.join( values )
+            if query or not args_passed:
+                # If query is forced or no args are passed, query the __inst
+                return self.__inst.query(command.format(cmd=self.name+'?'))
+            # Else write to __inst
+            return self.__inst.write(command.format(cmd=self.name))
 
 
         #--- static methods ---

--- a/easy_scpi/scpi_instrument.py
+++ b/easy_scpi/scpi_instrument.py
@@ -97,23 +97,21 @@ class Property( object ):
             )
 
 
-        def __call__( self, *values, query=False):
+        def __call__(self, *values, query=False):
             """
             Calls an SCPI command. If no values are passed it acts as a query 'COMMand?'
             If values are passed it acts as a write 'COMMand [values]'.
             For queries that require arguments, query=True can be passed.
             """
-            # Set up command format.
-            command = '{cmd}'
-            if args_passed := len( values ) > 0:
-                # Parse args into understandable format
-                values = [ str( val ) for val in values ]
-                command += ' '+self.arg_separator.join( values )
+            # Boolean of whether args have been passed
+            args_passed = len( values ) > 0
+            # Parse args into scpi understandable format
+            args = ' '+self.arg_separator.join(map(str, values)) if args_passed else ''
             if query or not args_passed:
                 # If query is forced or no args are passed, query the __inst
-                return self.__inst.query(command.format(cmd=self.name+'?'))
+                return self.__inst.query(self.name+'?'+args)
             # Else write to __inst
-            return self.__inst.write(command.format(cmd=self.name))
+            return self.__inst.write(self.name+args)
 
 
         #--- static methods ---

--- a/easy_scpi/scpi_instrument.py
+++ b/easy_scpi/scpi_instrument.py
@@ -97,22 +97,23 @@ class Property( object ):
             )
 
 
-        def __call__(self, *values, query=False):
+        def __call__(self, *values, query=None):
             """
             Calls an SCPI command. If no values are passed it acts as a query 'COMMand?'
             If values are passed it acts as a write 'COMMand [values]'.
             For queries that require arguments, query=True can be passed.
+            Alternatively for writes that need no arguments, query=False can be passed.
             """
             # Boolean of whether args have been passed
             args_passed = len( values ) > 0
             # Parse args into scpi understandable format
             args = ' '+self.arg_separator.join(map(str, values)) if args_passed else ''
-            if query or not args_passed:
-                # If query is forced or no args are passed, query the __inst
+            # When query is not passed, default to querying when no args and writing when args
+            query = args_passed if query is None else query
+            if query:
                 return self.__inst.query(self.name+'?'+args)
             # Else write to __inst
             return self.__inst.write(self.name+args)
-
 
         #--- static methods ---
 


### PR DESCRIPTION
I know there was already a PR for this, #10. I feel it may be better to pass an optional kwarg to the call function for the events when args are required for a query, as demonstrated in these commits. 

Fully open to discussion on what is the best solution (while keeping the library simple).

```py
inst.measure.voltage('MIN', query=True) # Forces ['MEASure:VOLTage? MIN']
```

I didn't want to change how currently it works so passing query=False will not have the vice versa operation (forcing empty args to be a write command). Retrospectively maybe I should add that into this PR.