### PR TITLE
Adding tests for new functionality.

### DIFF
--- a/tests/instrument_mock.yaml
+++ b/tests/instrument_mock.yaml
@@ -26,3 +26,19 @@ devices:
           min: 1
           max: 100000
           type: float
+      frequency-max:
+        default: 100000
+        getter:
+          q: "FREQ? MAX"
+          r: "{:.2f}"
+        setter:
+          q: "FREQ"
+        specs:
+          type: float
+      frequency-min:
+        default: 1
+        getter:
+          q: "FREQ? MIN"
+          r: "{:.2f}"
+        specs:
+          type: float

--- a/tests/test_easy_scpi.py
+++ b/tests/test_easy_scpi.py
@@ -1,17 +1,39 @@
 import platform
+import pytest
 import easy_scpi as scpi
 import pathlib
 
-def test_easy_scpi():
+@pytest.fixture
+def blank_inst():
+    # Blank Instrument
+    return scpi.Instrument()
+
+@pytest.fixture
+def inst():
     inst = scpi.Instrument(
-        port="TCPIP::0.0.0.1::3000::SOCKET", 
-        port_match=False, 
-        read_termination="\n", 
+        port="TCPIP::0.0.0.1::3000::SOCKET",
+        port_match=False,
+        read_termination="\n",
         write_termination="\n",
         backend=str((pathlib.Path(__file__).parent /'instrument_mock.yaml@sim').resolve()),
     )
     inst.connect()
-    
+    return inst
+
+def test_property_syntax(blank_inst):
+    # Assert naming conventions work as expected.
+    assert blank_inst.a.name == "A"
+    assert blank_inst.a.b.name == "A:B"
+    assert blank_inst.a.b.c.name == "A:B:C"
+
+def test_prefix_syntax(blank_inst):
+    # Assert that prefixing of commands work.
+    blank_inst.prefix_cmds = True
+    assert blank_inst.a.name == ":A"
+    assert blank_inst.a.b.name == ":A:B"
+    assert blank_inst.a.b.c.name == ":A:B:C"
+
+def test_easy_scpi(inst):
     assert inst.id == "mock instrument"
     
     assert inst.query("FREQ?") == "100.00"
@@ -22,3 +44,9 @@ def test_easy_scpi():
     inst.freq(100.00)
     assert inst.read() == "OK"
     assert inst.freq() == "100.00"
+
+def test_argument_query(inst):
+    assert inst.query('FREQ? MAX') == "100000.00"
+    assert inst.freq('MAX', query=True) == "100000.00"
+    assert inst.query('FREQ? MIN') == "1.00"
+    assert inst.freq('MIN', query=True) == "1.00"

--- a/tests/test_easy_scpi.py
+++ b/tests/test_easy_scpi.py
@@ -1,13 +1,14 @@
 import platform
 import easy_scpi as scpi
+import pathlib
 
-def test_easy_scpi():      
+def test_easy_scpi():
     inst = scpi.Instrument(
         port="TCPIP::0.0.0.1::3000::SOCKET", 
         port_match=False, 
         read_termination="\n", 
         write_termination="\n",
-        backend='tests/instrument_mock.yaml@sim',
+        backend=str((pathlib.Path(__file__).parent /'instrument_mock.yaml@sim').resolve()),
     )
     inst.connect()
     


### PR DESCRIPTION
Owing to a *some* guilt at pushing some broken logic in my previous PR I'd like to thank you for the prompt fixes on your end and apologise for this.  I am endeavouring to make sure it doesn't happen again (and hopefully repay some of my error), so have create some tests of my own.

- I've added pytest fixtures for a blank_instrument - no visa backend, and converted the simulated backend into a fixture to allow reuse across tests.
- I've added a test for the naming conventions: ensuring ```inst.a.b.c == A:B:C``` and when `prefix_cmds=True` this should instead `== :A:B:C`
- Added a test for new query functionality ensuring that it passes arg as expected. *note: couldn't work out how to test the comparable `FREQ MIN` to test the setting of frequency to MIN. Doesn't seem like the  `pyvisa-sim` has this functionality.